### PR TITLE
Update runs-on value in workflows

### DIFF
--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -16,7 +16,8 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on:
+      group: default
     container:
       image: python:${{ inputs.python-version }}
     steps:

--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -20,7 +20,8 @@ on:
 
 jobs:
   sync_readme_to_notion:
-    runs-on: self-hosted
+    runs-on:
+      group: default
     name: Checkout and upload Readme to Notion
     container:
       image: ubuntu:22.04

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,7 +5,8 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: self-hosted
+    runs-on:
+      group: default
     container:
       image: ubuntu:22.04
     steps:


### PR DESCRIPTION
This pull request updates the `runs-on` value in the workflows to use the `group: default` instead of `self-hosted`. This change ensures consistency and improves the readability of the workflows.