### PR TITLE
Add Semver action for comparing GitHub tags with input version

### DIFF
--- a/semver/README.md
+++ b/semver/README.md
@@ -1,0 +1,21 @@
+# Semver
+
+## Description
+
+Compare last semver of GitHub tag with input version. Return a boolean to indicate if the version should be bumped.
+
+## Inputs
+
+| name      | description     | required | default |
+| --------- | --------------- | -------- | ------- |
+| `version` | Current version | `true`   | `""`    |
+
+## Outputs
+
+| name   | description                                         |
+| ------ | --------------------------------------------------- |
+| `bump` | Boolean to indicate if the version should be bumped |
+
+## Runs
+
+This action is a `composite` action.

--- a/semver/action.yml
+++ b/semver/action.yml
@@ -1,0 +1,35 @@
+name: "Semver comparaison"
+description: "Compare last semver of GitHub tag with input version. Return a boolean to indicate if the version should be bumped."
+
+inputs:
+  version:
+    description: "Current version"
+    required: true
+
+outputs:
+  bump:
+    description: "Boolean to indicate if the version should be bumped"
+    value: ${{ steps.compare.outputs.bump }}
+
+runs:
+  using: "composite"
+  steps:
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        with:
+          semver_only: true
+          initial_version: '0.0.0'
+      - name: 'Compare Versions'
+        shell: bash
+        id: compare
+        run: |
+          PREVIOUS_TAG=$(echo ${{ steps.previoustag.outputs.tag }} | sed 's/\.//g')
+          CURRENT_VERSION=$(echo ${{ steps.currentversion.outputs.version }} | sed 's/\.//g')
+          echo "Previous tag: $PREVIOUS_TAG"
+          echo "Current version: $CURRENT_VERSION"
+          if [ $PREVIOUS_TAG -lt $CURRENT_VERSION ]; then
+            echo ::set-output name=bump::true
+          else
+            echo ::set-output name=bump::false
+          fi


### PR DESCRIPTION
This pull request adds a new action called "Semver" that compares the last semver of a GitHub tag with the input version. It returns a boolean value indicating whether the version should be bumped. The action takes a required input parameter called "version" which represents the current version. The output of the action is a boolean value called "bump". This action is a composite action and consists of two steps: "Get Previous tag" and "Compare Versions". The "Get Previous tag" step retrieves the latest tag using the actions-ecosystem/action-get-latest-tag@v1 action, while the "Compare Versions" step compares the previous tag with the current version and sets the "bump" output accordingly.