### PR TITLE
Clear Docker Buildx cache before building image

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -96,6 +96,9 @@ jobs:
             echo "::set-output name=file::${{ inputs.file }}"
           fi
 
+      - name: Clear Docker Buildx cache
+        run: docker builder prune -af
+
       - name: Build and push Docker image (version, target)
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Workflow improvement:

* [`.github/workflows/docker-ghcr.yml`](diffhunk://#diff-f50b4523ed149b8aee91f12aaa700f904db5b6749c01494c84b919e0d0d43e92R99-R101): Added a step to clear the Docker Buildx cache using `docker builder prune -af` to ensure a clean build environment.