### PR TITLE
Update pre-commit workflow to use new Docker image

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,14 +7,11 @@ jobs:
   pre-commit:
     runs-on: sonu-github-arc
     container:
-      image: cicirello/pyaction:4.29
+      image: ghcr.io/catie-aq/pre-commit_docker:latest
     steps:
       - uses: actions/checkout@v4
         with:
           path: folder
-      - run: cd folder
-      - name: Install pre-commit
-        run: pip install pre-commit
       - name: Run pre-commit
         run: |
           cd folder/ \


### PR DESCRIPTION
* Updated the Docker image in the `pre-commit` job to `ghcr.io/catie-aq/pre-commit_docker:main` from `cicirello/pyaction:4.29`.
* Removed unnecessary steps to change directories and install `pre-commit`, as these are now handled by the new Docker image.