### PR TITLE
Choix de la version du container dans pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,12 +2,17 @@ name: Run pre-commit
 
 on:
   workflow_call:
+    inputs:
+      image-tag:
+        required: false
+        type: string
+        default: "latest"
 
 jobs:
   pre-commit:
     runs-on: sonu-github-arc
     container:
-      image: ghcr.io/catie-aq/pre-commit_docker:latest
+      image: ghcr.io/catie-aq/pre-commit_docker:${{ inputs.image-tag }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Enhancements to workflow flexibility:

* [`.github/workflows/pre-commit.yaml`](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R5-R15): Added an optional `image-tag` input parameter with a default value of "latest" and updated the Docker image reference to use this input parameter.