### PR TITLE
Add workflow for converting Markdown to LaTeX PDF

### DIFF
--- a/.github/workflows/md-latex-pdf.yml
+++ b/.github/workflows/md-latex-pdf.yml
@@ -1,0 +1,67 @@
+name: Markdown to CATIE LaTeX PDF
+
+on:
+  workflow_call:
+    secrets:
+      personal_access_token:
+        required: true
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on:
+      group: default
+    container:
+      image: pandoc/extra:3.9.0.0-alpine
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apk add --no-cache bash nodejs npm
+
+      - name: Install git
+        run: |
+          apk add --no-cache git
+
+      - name: Configure PAT for private repositories
+        env:
+          PRIVATE_REPO_PAT: ${{ secrets.personal_access_token }}
+        run: |
+          if [ -z "${PRIVATE_REPO_PAT}" ]; then
+            echo "PRIVATE_REPO_PAT is not set. Cloning private repositories may fail." >&2
+          else
+            echo "::add-mask::${PRIVATE_REPO_PAT}"
+            git config --global url."https://x-access-token:${PRIVATE_REPO_PAT}@github.com/".insteadOf "https://github.com/"
+          fi
+
+      - name: Configure TeX Live mirror
+        run: |
+          TL_YEAR=$(tlmgr --version | awk '/TeX Live .* version [0-9]{4}$/ {print $NF; exit}' || true)
+          [ -n "${TL_YEAR}" ] || { echo "Unable to detect TeX Live year from tlmgr --version"; exit 1; }
+
+          tlmgr option repository "https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${TL_YEAR}/tlnet-final"
+
+      - name: Install TeX packages
+        run: |
+          tlmgr install placeins mathtools nomencl hyphenat lastpage lipsum newunicodechar pdfpages jknapltx raleway pdflscape rsfs soul
+
+      - name: Build PDF
+        run: |
+          bash compile.sh
+
+      - name: Upload PDF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdf-documents
+          path: out/*.pdf
+          if-no-files-found: error
+
+      - name: Create GitHub Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/*.pdf
+          generate_release_notes: true

--- a/.github/workflows/md-latex-pdf.yml
+++ b/.github/workflows/md-latex-pdf.yml
@@ -10,8 +10,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on:
-      group: default
+    runs-on: sonu-github-arc
     container:
       image: pandoc/extra:3.9.0.0-alpine
     steps:
@@ -20,22 +19,13 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          apk add --no-cache bash nodejs npm
-
-      - name: Install git
-        run: |
-          apk add --no-cache git
+          apk add --no-cache bash nodejs npm git
 
       - name: Configure PAT for private repositories
         env:
           PRIVATE_REPO_PAT: ${{ secrets.personal_access_token }}
         run: |
-          if [ -z "${PRIVATE_REPO_PAT}" ]; then
-            echo "PRIVATE_REPO_PAT is not set. Cloning private repositories may fail." >&2
-          else
-            echo "::add-mask::${PRIVATE_REPO_PAT}"
-            git config --global url."https://x-access-token:${PRIVATE_REPO_PAT}@github.com/".insteadOf "https://github.com/"
-          fi
+          git config --global url."https://x-access-token:${PRIVATE_REPO_PAT}@github.com/${GITHUB_REPOSITORY_OWNER}/".insteadOf "https://github.com/${GITHUB_REPOSITORY_OWNER}/"
 
       - name: Configure TeX Live mirror
         run: |
@@ -65,3 +55,4 @@ jobs:
         with:
           files: out/*.pdf
           generate_release_notes: true
+          draft: true

--- a/.github/workflows/pandoc-pdf.yml
+++ b/.github/workflows/pandoc-pdf.yml
@@ -56,3 +56,4 @@ jobs:
           files: out/*.pdf
           generate_release_notes: true
           draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pandoc-pdf.yml
+++ b/.github/workflows/pandoc-pdf.yml
@@ -1,4 +1,4 @@
-name: Markdown to CATIE LaTeX PDF
+name: Pandoc PDF
 
 on:
   workflow_call:

--- a/.github/workflows/pandoc-pdf.yml
+++ b/.github/workflows/pandoc-pdf.yml
@@ -6,8 +6,6 @@ on:
       personal_access_token:
         required: true
 
-permissions: read-all
-
 jobs:
   build:
     runs-on: sonu-github-arc

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Ce dépôt contient une collection de workflows réutilisables. Les workflows so
 - [Docker GHCR](docs/docker-ghcr.md) : Construit et publie une image Docker sur GitHub Container Registry.
 - [Docker Nexus](docs/docker-nexus.md) : Construit et publie une image Docker sur Nexus Repository Manager.
 - [GitHub Project](docs/github-project.md) : Ajoute tous les problèmes et les demandes de tirage à un projet.
+- [Pandoc PDF](docs/pandoc-pdf.md) : Convertit un fichier Markdown en PDF en utilisant Pandoc.
 - [Pre Commit](docs/pre-commit.md) : Exécute les hooks pre-commit d'un projet.

--- a/docs/pandoc-pdf.md
+++ b/docs/pandoc-pdf.md
@@ -1,0 +1,55 @@
+# Génération de PDF avec Pandoc
+
+Ce workflow GitHub Actions est déclenché lorsqu'un appel de workflow est effectué. Il compile des documents PDF avec Pandoc, publie les fichiers en artefacts, puis crée une release GitHub (draft) quand l'exécution est lancée sur un tag.
+
+## Secrets
+
+| nom                     | description                                                                                             | requis |
+|-------------------------|---------------------------------------------------------------------------------------------------------|--------|
+| `personal_access_token` | Token utilisé pour accéder aux dépôts privés de l'organisation (ex: dépendances, submodules, templates) | `true` |
+
+## Prérequis dans le dépôt appelant
+
+- Un script `compile.sh` à la racine du dépôt.
+- Le script doit générer les fichiers PDF dans `out/*.pdf`.
+- Le secret `personal_access_token` doit être défini dans le dépôt appelant.
+
+## Jobs
+
+Le workflow contient un seul job, `build`.
+
+### build
+
+Ce job s'exécute sur le runner `sonu-github-arc` dans le conteneur `pandoc/extra:3.9.0.0-alpine`.
+
+Les étapes pour ce job sont :
+
+- Extraire le code en utilisant `actions/checkout@v4`.
+- Installer les dépendances système (`bash`, `nodejs`, `npm`, `git`).
+- Configurer git avec le `personal_access_token` pour les dépôts privés de `github.com/${GITHUB_REPOSITORY_OWNER}`.
+- Détecter l'année TeX Live et configurer le miroir `tlnet-final` correspondant.
+- Installer les paquets TeX nécessaires via `tlmgr`.
+- Exécuter `bash compile.sh`.
+- Publier les PDF générés en artefacts (`actions/upload-artifact@v4`, nom `pdf-documents`, chemin `out/*.pdf`).
+- Créer une release GitHub draft sur tag avec `softprops/action-gh-release@v2`.
+
+## Exemple d'utilisation
+
+```yaml
+name: Build PDF
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "*"
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: catie-aq/generic_workflows/.github/workflows/pandoc-pdf.yml@add-md-latex-pdf-workflow
+    secrets:
+      personal_access_token: ${{ secrets.PAT }}
+```


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for converting Markdown documents to CATIE LaTeX PDFs. The workflow automates the build process, installs required dependencies, and handles artifact uploads and release creation.

New workflow for Markdown to LaTeX PDF conversion:

* Added `.github/workflows/md-latex-pdf.yml` to define a GitHub Actions workflow that builds PDFs from Markdown using a containerized Pandoc environment.
* Configured steps for dependency installation for document compilation.
* Included artifact upload for generated PDFs and automated GitHub release creation when a tag is pushed.
* Provided support for accessing private repositories via a Personal Access Token (PAT) for seamless cloning during the workflow.