### PR TITLE
Add BuildKit secrets support in Docker workflow

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -22,6 +22,9 @@ on:
       build_args:
         description: "Build Args for Dockerfile"
         required: false
+      build_secrets:
+        description: "BuildKit secrets for Dockerfile --mount=type=secret"
+        required: false
       PAT:
         description: "Personal Access Token for private submodules or private images"
         required: false
@@ -96,13 +99,17 @@ jobs:
             echo "::set-output name=file::${{ inputs.file }}"
           fi
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Build and push Docker image (version, target)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
-          context: ${{ inputs.Dockerfile}}
+          context: ${{ inputs.Dockerfile }}
           file: ${{ steps.file.outputs.file }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ inputs.target }}
           build-args: ${{ secrets.build_args }}
+          secrets: ${{ secrets.build_secrets }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-ghcr.yml` workflow to improve Docker image builds by adding support for BuildKit secrets, upgrading Docker actions, and enhancing build configuration flexibility. The main changes are grouped below:

**Docker build enhancements:**

* Added a new input parameter `build_secrets` to allow passing BuildKit secrets to Docker builds, enabling more secure handling of sensitive data during the build process.
* Updated the Docker build step to pass the `build_secrets` input as secrets to the Docker build action.

**Dependency and action updates:**

* Upgraded the `docker/build-push-action` from version 2 to version 6 for improved features and compatibility.
* Added a new step to set up Docker Buildx using the `docker/setup-buildx-action@v4`, which is required for advanced build features like BuildKit secrets.